### PR TITLE
Remove lonely closing tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,9 +3,6 @@
 <head>
 <title>Graham McBain's amazing Javascript!</title>
 <link id="pagestyle" rel="stylesheet" type="text/css" href="css/demo.css">
-
-</script>
-
 </head>
 <body>
 <div class="wrap ">


### PR DESCRIPTION
The example index.html file had a closing 
</script> tag which did not have an opening
tag.